### PR TITLE
Add configuration to implement GitVersion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          path: .
+          fetch-depth: 0
+      - name: Fix tags
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} 
       - name: Restore the project
         run: |
             dotnet build -c Release || echo true

--- a/.gitversion
+++ b/.gitversion
@@ -1,0 +1,28 @@
+# This file specifies the (first part of the) version number and some options used by the
+# "tap sdk gitverion" command and the $(gitversion) macro in package.xml
+
+# This is the version number that will be used. Prerelease numbers are calculated by 
+# counting git commits since the last change in this value.
+version = 0.1.0
+
+# A version is determined to be a "beta" prerelease if it originates from the default branch
+# The default branch is the first branch that matches the following regular expession.
+# Uncomment to change the default.
+beta branch = main
+
+# When specified multiple times later sprcifications of "beta branch" will only be tried
+# if earlier ones did not match any branches in the git repository
+#beta branch = develop
+#beta branch = dev
+#beta branch = master
+
+# A version is determined to be a "rc" prerelease if it originates from a branch that matches
+# the following regular expression.
+# Uncomment to change the default.
+#release branch = release[0-9x]*
+
+# A version is determined to be a release (no prerelease identifiers, just the version number
+# specified in this file), if it originates from a commit that has an annotated tag that matches
+# the following regular expression. (Note that the actual value of the tag is not used).
+# Uncomment to change the default.
+#release tag = v\d+\.\d+


### PR DESCRIPTION
* **build.yaml**  - the change pulls the tags from git so that the metadata is available for GitVersion to act on
* **.gitversion** - default configuration for GitVersion with OpenTAP. With this in place, builds on **main** branch will get a **beta** version, released versions can be created by annotating with a tag like '**v0.1.0**', all other branches build as **alpha** versions.

Documentation about OpenTAP and GitVersion can be found here: https://doc.opentap.io/Developer%20Guide/Plugin%20Packaging%20and%20Versioning/#versioning