### PR TITLE
Resolve bug stopping robot from moving.

### DIFF
--- a/openTap/UR_Prototype/UR3e.py
+++ b/openTap/UR_Prototype/UR3e.py
@@ -35,7 +35,7 @@ class UR3e(Instrument):
                 self.log.Error("Could not connect to {}:{} Error: {}".format(HOST, PORT, e))
                 return False
             try:
-                command + '\n'
+                command = command + '\n'
                 self.log.Info(f"Sending command {command!r}")
                 client_socket.sendall(command.encode())
                 response = client_socket.recv(1024)    


### PR DESCRIPTION
1. File UR3e.py, command variable is missing required newline character.

### Summary
Branch resolves bug that prevents the robot from moving when executing a test plan involving `UR3e` tool and `MoveCobot` test step. The variable `command` within `UR3e.py` was not properly appending the required newline character; this branch append it correctly. 

### Reproduce Bug
Create and run a test plan containing a `UR3e` tool and `MoveCobot` test step. Command will pass but UR3e simulator will not move.

### Fixed Behavior
UR simulator will now move when executing a test plan containing a `UR3e` tool and `MoveCobot` test step. 

### Files of Interest
`UR3e.py`
