### PR TITLE
Added the option to abstract using the movel UR command

### DIFF
--- a/openTap/UR_Prototype/MoveCobot.py
+++ b/openTap/UR_Prototype/MoveCobot.py
@@ -22,6 +22,11 @@ class MoveCobot(TestStep):
         .add_attribute(OpenTap.Display("Mode", "Values from Available Values can be selected here.", "Mode"))
     Available = property(List[String], None)\
         .add_attribute(OpenTap.Display("Available Values", "Select which values are available for 'Mode'.", "Mode"))
+    C_Choice = property(String, "Joint")\
+        .add_attribute(OpenTap.AvailableValues("Commands"))\
+        .add_attribute(OpenTap.Display("Movement Choices", "Values from Command choices can be selected here.", "Movement Choices"))
+    Commands = property(List[String], None)\
+        .add_attribute(OpenTap.Display("Movements", "Select how you want to move the cobot.", "Movements"))
 
 
     def __init__(self):
@@ -30,12 +35,17 @@ class MoveCobot(TestStep):
         self.Available = List[String]()
         self.Available.Add("Seek Mode")
         self.Available.Add("URScript Mode")
+        self.Commands = List[String]()
+        self.Commands.Add("Joint")
+        self.Commands.Add("Linear")
 
 
     def Run(self):
         super().Run()
         
         if self.Mode == "Seek Mode":
+            if self.C_Choice == "Linear":
+                self.ur3e_cobot.set_command("movel")
             self.command = self.ur3e_cobot.seek_target_position()
 
         # Sends move command to cobot.

--- a/openTap/UR_Prototype/UR3e.py
+++ b/openTap/UR_Prototype/UR3e.py
@@ -17,6 +17,8 @@ class UR3e(Instrument):
     
     ip_address = property(String, "192.168.56.101")\
         .add_attribute(OpenTap.Display("IP Address", "The static IP address of the UR3e cobot."))
+    
+    command = "movej"
 
     def __init__(self):
         super(UR3e, self).__init__()
@@ -28,6 +30,8 @@ class UR3e(Instrument):
         self.initial_position_command = ""
         self.InputValue = Input[String]()
 
+    def set_command(self, comm):
+        self.command = comm
 
     def connect_to_cobot(self) -> socket.socket:
         """
@@ -251,7 +255,7 @@ class UR3e(Instrument):
         """
 
         self.joint_values[index] += 0.1
-        seek_command = f"movej({self.joint_values}, v=1.0, a=1.0)\n"
+        seek_command = self.command + f"({self.joint_values}, v=1.0, a=1.0)\n"
         print(seek_command)
         self.send_request_movement(seek_command)
 
@@ -266,7 +270,7 @@ class UR3e(Instrument):
 
         self.joint_values[index] -= 0.1
         print(self.joint_values)
-        seek_command = f"movej({self.joint_values}, v=1.0, a=1.0)\n"
+        seek_command = self.command + f"({self.joint_values}, v=1.0, a=1.0)\n"
         print(seek_command)
         self.send_request_movement(seek_command)
 
@@ -280,8 +284,8 @@ class UR3e(Instrument):
             initial (list): The initial position of the cobot.
         """
 
-        self.target_position_command = f"movej({self.joint_values}, v=1.0, a=1.0)\n"
-        initial_position_command = f"movej({self.initial_position}, v=1.0, a=1.0)\n"
+        self.target_position_command = self.command + f"({self.joint_values}, v=1.0, a=1.0)\n"
+        initial_position_command = self.command + f"({self.initial_position}, v=1.0, a=1.0)\n"
         print(f"Initial: {initial_position_command}, target:{self.target_position_command}")
 
         # Potential bug:


### PR DESCRIPTION
The move test step contains the option to move joints or the cobot linearly. When the linear option is selected, the movel command is sent to the cobot.